### PR TITLE
Add 'cd' to installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following commands should be sufficient:
 
 ```
 git clone https://github.com/kensung-lab/INSurVeyor
+cd INSurVeyor/
 ./build_htslib.sh
 cmake -DCMAKE_BUILD_TYPE=Release . && make
 ```


### PR DESCRIPTION
Definitely trivial, but sufficient to throw off novice Linux users.